### PR TITLE
chore(deps): pnpm を v11 にアップデート

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Enable corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: pnpm

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -29,7 +29,7 @@ jobs:
         shell: bash
       - name: ブラウザのキャッシュを復元
         id: restore-chromium
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ steps.version-checker.outputs.playwright-version }}
@@ -39,13 +39,13 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
         if: ${{ steps.restore-chromium.outputs.cache-hit != 'true' }}
       - name: ブラウザのキャッシュを保存
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: ${{ steps.restore-chromium.outputs.cache-hit != 'true' }}
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ steps.version-checker.outputs.playwright-version }}
       - name: ビルドキャッシュを復元
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
@@ -57,7 +57,7 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
       - name: Playwrightのテストを実行
         run: pnpm exec playwright test --workers=2
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - run: corepack enable
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: "24"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/package.json
+++ b/package.json
@@ -66,5 +66,5 @@
     "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.4"
   },
-  "packageManager": "pnpm@10.27.0"
+  "packageManager": "pnpm@11.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "lint": "oxlint --type-aware",
     "lint:fix": "oxlint --fix",
     "preinstall": "npx only-allow pnpm",
-    "setup": "corepack enable pnpm",
     "start": "next start",
     "test": "vitest run",
     "test:e2e": "playwright test",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,4 @@ onlyBuiltDependencies:
   - "esbuild"
   - "lefthook"
   - "sharp"
-minimumReleaseAge: 1420
+saveExact: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 packages:
   - "./"
-onlyBuiltDependencies:
-  - "esbuild"
-  - "lefthook"
-  - "sharp"
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  sharp: true
 saveExact: true


### PR DESCRIPTION
## 概要

pnpm を v10.27.0 から v11.0.1 にアップデートし、それに伴う設定の調整と GitHub Actions の更新を行います。

## 変更内容

### pnpm v11 へのアップデート
- `package.json` の `packageManager` を `pnpm@10.27.0` → `pnpm@11.0.1` に更新
- pnpm v11 で `onlyBuiltDependencies` が廃止されたため `pnpm-workspace.yaml` で `allowBuilds` に変更
- `.npmrc` の `save-exact=true` を `pnpm-workspace.yaml` の `saveExact: true` に統合し、`.npmrc` を削除

### corepack の廃止
- GitHub Actions ワークフローで `corepack enable` の代わりに `pnpm/action-setup` を使用
- `package.json` から不要となった `setup` スクリプト（`corepack enable pnpm`）を削除

### GitHub Actions の更新
- `actions/checkout` を v6.0.2 に更新
- `actions/setup-node` を v6.4.0 に更新
- `actions/cache` / `actions/cache/restore` を v5.0.5 に更新
- `actions/upload-artifact` を v7.0.1 に更新
- `dependabot/fetch-metadata` を v3.1.0 に更新（コメント追加）

## 影響範囲

- 開発者は pnpm v11 をローカルにインストールする必要があります（`packageManager` フィールドにより自動的にバージョンが解決されます）
- CI 環境では `pnpm/action-setup` により自動的に正しいバージョンの pnpm がセットアップされます

## 確認事項

- [ ] CI（codecheck / playwright）がグリーン
- [ ] ローカルで `pnpm install` および `pnpm run build` が成功すること