### PR TITLE
chore: tsconfig の型チェックを厳格化

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -134,7 +134,10 @@ const SelectMonth = () => {
       value={state.focusedDate.month}
       onChange={(key) => {
         if (typeof key === "number") {
-          state.setFocusedDate(months[key - 1].date);
+          const month = months[key - 1];
+          if (month) {
+            state.setFocusedDate(month.date);
+          }
         }
       }}
     >
@@ -171,7 +174,7 @@ const SelectYear = () => {
   return (
     <Select
       aria-label="Year"
-      selectedKey={years[20].id}
+      selectedKey={years[20]?.id}
       onSelectionChange={(key) => {
         const selected = years.find((year) => year.id == key);
         if (selected) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,11 @@
     "resolveJsonModule": true,
     "allowJs": true,
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true, // ファイル名の大文字・小文字の不一致によるバグを防ぐ
+    "noUncheckedIndexedAccess": true, // インデックスアクセスの型安全を強制
     "noEmit": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
## 概要

[newt239/chat の tsconfig](https://github.com/newt239/chat/blob/2504c603395a2816c785e5bc3313fe61981dcabc/frontend/tsconfig.json) を参照し、現状の tsconfig より厳しい設定を取り入れました。

## 変更内容

`tsconfig.json` に以下の設定を追加しました（`strict: true` で既に有効な `strictNullChecks` は除外）。

- `noUnusedLocals`
- `noUnusedParameters`
- `noFallthroughCasesInSwitch`
- `forceConsistentCasingInFileNames`
- `noUncheckedIndexedAccess`

`noUncheckedIndexedAccess` の追加に伴い、`src/components/ui/calendar.tsx` で発生した型エラー（インデックスアクセスの undefined チェック）を修正しました。

## 確認

- `pnpm run codecheck` がパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)