### PR TITLE
ci: PR作成者を自動でアサインするワークフローを追加

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,27 @@
+name: Auto Assign Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                assignees: [context.payload.pull_request.user.login],
+              });
+            } catch (error) {
+              core.warning(`PR作成者のアサインに失敗しました: ${error.message}`);
+            }


### PR DESCRIPTION
## 概要

PRが開かれた（または再オープンされた）際に、作成者を自動でassigneeに設定するGitHub Actionsワークフローを追加します。

[newt239/ginga-ui#82](https://github.com/newt239/ginga-ui/pull/82) と同じ機能をこのリポジトリにも導入するものです。

## 変更内容

- `.github/workflows/auto-assign-author.yml` を新規追加
  - `pull_request_target` の `opened` / `reopened` をトリガーに、`actions/github-script` でPR作成者をアサインする

## 既存の書き方への準拠

- アクションはコミットSHA + バージョンコメントでピン留め（`actions/github-script@3a2844b...` # v9.0.0）
- ファイル拡張子は本リポジトリの既存ワークフローに合わせて `.yml` に統一（ginga-ui では `.yaml` が多数派だったが、本リポジトリは `.yml` が多数派のため）
- step に `name` を付与

🤖 Generated with [Claude Code](https://claude.com/claude-code)