### PR TITLE
feat: ls-lint を導入しファイル名規約を自動チェック

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,12 +10,11 @@
     "deny": [
       "Bash(rm:*)",
       "Bash(git reset:*)",
-      "Bash(git checkout:*)",
       "Bash(git merge:*)",
       "Bash(git rebase:*)",
       "Bash(git reset:*)"
     ],
-    "ask": ["Bash(git add:*)", "Bash(git commit:*)", "Bash(git push:*)"]
+    "ask": ["Bash(git checkout:*)", "Bash(git add:*)", "Bash(git commit:*)", "Bash(git push:*)"]
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": ["deepwiki", "playwright", "context7"],

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -25,6 +25,8 @@ jobs:
         run: pnpm run lint
       - name: Oxfmt
         run: pnpm run format
+      - name: ls-lint
+        run: pnpm run ls-lint
       - name: Knip
         run: pnpm run knip
       - name: Test

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,5 +1,5 @@
 ls:
-  .dir: kebab-case | regex:\..+
+  .dir: kebab-case | regex:^\..+$
   .ts: kebab-case
   .tsx: kebab-case
   .mjs: kebab-case
@@ -13,7 +13,7 @@ ls:
   .md: kebab-case | SCREAMING_SNAKE_CASE
 
   src:
-    .dir: kebab-case | regex:\(.+\) | regex:\[.+\]
+    .dir: kebab-case | regex:^\(.+\)$ | regex:^\[.+\]$
     .ts: kebab-case
     .tsx: kebab-case
     .css: kebab-case

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,0 +1,41 @@
+ls:
+  .dir: kebab-case | regex:\..+
+  .ts: kebab-case
+  .tsx: kebab-case
+  .mjs: kebab-case
+  .json: kebab-case
+  .yml: kebab-case
+  .yaml: kebab-case
+  .svg: kebab-case
+  .d.ts: kebab-case
+  .config.ts: kebab-case
+  .config.mjs: kebab-case
+  .md: kebab-case | SCREAMING_SNAKE_CASE
+
+  src:
+    .dir: kebab-case | regex:\(.+\) | regex:\[.+\]
+    .ts: kebab-case
+    .tsx: kebab-case
+    .css: kebab-case
+    .spec.ts: kebab-case
+    .spec.tsx: kebab-case
+    .stories.tsx: kebab-case
+
+  tests:
+    .dir: kebab-case
+    .ts: kebab-case
+    .spec.ts: kebab-case
+
+  drizzle:
+    .sql: snake_case
+
+ignore:
+  - node_modules
+  - .next
+  - .git
+  - .claude
+  - .ls-lint.yml
+  - .oxlintrc.json
+  - .oxfmtrc.json
+  - .mcp.json
+  - drizzle/meta

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,3 +9,6 @@ pre-commit:
       run: pnpm run format:fix
       stage_fixed: true
       fail_text: フォーマットエラーがあります
+    ls-lint:
+      run: pnpm run ls-lint
+      fail_text: ファイル名がkebab-case規約に違反しています

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "codecheck": "pnpm run typecheck && pnpm run lint && pnpm run format && pnpm run knip",
+    "codecheck": "pnpm run typecheck && pnpm run lint && pnpm run format && pnpm run ls-lint && pnpm run knip",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
     "dev": "next dev --turbopack",
@@ -13,6 +13,7 @@
     "knip": "knip",
     "lint": "oxlint --type-aware",
     "lint:fix": "oxlint --fix",
+    "ls-lint": "ls-lint",
     "preinstall": "npx only-allow pnpm",
     "start": "next start",
     "test": "vitest run",
@@ -42,6 +43,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@ls-lint/ls-lint": "2.3.1",
     "@playwright/test": "1.60.0",
     "@tailwindcss/postcss": "4.3.0",
     "@testing-library/dom": "10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@ls-lint/ls-lint':
+        specifier: 2.3.1
+        version: 2.3.1
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -1027,6 +1030,12 @@ packages:
     resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
     cpu: [x64]
     os: [win32]
+
+  '@ls-lint/ls-lint@2.3.1':
+    resolution: {integrity: sha512-vPe6IDByQnQRTxcAYjTxrmga/tSIui50VBFTB5KIJWY3OOFmxE2VtymjeSEfQfiMbhZV/ZPAqYy2lt8pZFQ0Rw==}
+    cpu: [x64, arm64, s390x, ppc64le]
+    os: [darwin, linux, win32]
+    hasBin: true
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -3596,6 +3605,8 @@ snapshots:
 
   '@libsql/win32-x64-msvc@0.5.29':
     optional: true
+
+  '@ls-lint/ls-lint@2.3.1': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:


### PR DESCRIPTION
## 概要

ls-lint を導入し、プロジェクト内のファイル名を原則として kebab-case に統一・自動チェックできるようにしました。npm script・lefthook（pre-commit）・GitHub Actions の 3 点で強制します。

## 変更内容

- `@ls-lint/ls-lint` を devDependency に追加
- `.ls-lint.yml` を新規作成し、プロジェクト全体を領域別ルールでチェック
  - `src` / `tests`: kebab-case（Next.js の `(protected)` / `[id]` のみディレクトリで例外許可）
  - `*.md`: kebab-case または大文字（README / CHANGELOG / AGENTS 等）
  - `drizzle`: snake_case（生成物）。`drizzle/meta` は ignore
  - `.github` / `.vscode` 等の先頭ドットディレクトリ、ドット config ファイルは許可 / ignore
- `package.json` に `ls-lint` script を追加し、`codecheck` に組み込み
- `lefthook` の pre-commit に `ls-lint` チェックを追加
- GitHub Actions `codecheck.yml` に `ls-lint` ステップを追加
- `.claude/settings.json`: `git checkout` を deny から ask に変更（別コミット）

## 補足

- 既存の `src` / `tests` 配下のファイルは既にすべて kebab-case 準拠のため、ファイルのリネームは発生していません。
- `pnpm run ls-lint` および `pnpm run codecheck` がローカルで通過することを確認済みです。

## 確認事項

- [ ] CI（Codecheck）が通ること
