### PR TITLE
feat(env): t3-env による型安全な環境変数バリデーションの導入

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,17 +1,9 @@
 import { defineConfig } from "drizzle-kit";
 
-const databaseUrl = process.env.TURSO_CONNECTION_URL;
-if (typeof databaseUrl !== "string" || databaseUrl.length === 0) {
-  throw new Error("TURSO_CONNECTION_URL が設定されていません。");
-}
-
-const authToken = process.env.TURSO_AUTH_TOKEN!;
-if (typeof authToken !== "string" || authToken.length === 0) {
-  throw new Error("TURSO_AUTH_TOKEN が設定されていません。");
-}
+import { env } from "./src/lib/env";
 
 export default defineConfig({
-  dbCredentials: { authToken, url: databaseUrl },
+  dbCredentials: { authToken: env.TURSO_AUTH_TOKEN, url: env.TURSO_CONNECTION_URL },
   dialect: "turso",
   out: "./drizzle",
   schema: "./src/lib/drizzle/schema/index.ts",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+import "./src/lib/env";
+
 const nextConfig: NextConfig = {
   cacheComponents: true,
   typedRoutes: true,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@internationalized/date": "3.12.2",
     "@libsql/client": "0.17.4",
     "@react-aria/i18n": "3.13.1",
+    "@t3-oss/env-nextjs": "0.13.11",
     "better-auth": "1.6.23",
     "drizzle-orm": "0.45.2",
     "motion": "12.42.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@react-aria/i18n':
         specifier: 3.13.1
         version: 3.13.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@t3-oss/env-nextjs':
+        specifier: 0.13.11
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       better-auth:
         specifier: 1.6.23
         version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.3))(next@16.2.10(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))
@@ -1742,6 +1745,40 @@ packages:
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@t3-oss/env-core@0.13.11':
+    resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
+  '@t3-oss/env-nextjs@0.13.11':
+    resolution: {integrity: sha512-NC+3j7YWgpzdFu1t5y/8wqibTK0lm5RS4bjXA1n8uwik3wIR4iZM4Fa+U2BaMa5k3Qk8RZiYhoAIX0WogmGkzg==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
@@ -3974,6 +4011,18 @@ snapshots:
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
+
+  '@t3-oss/env-core@0.13.11(typescript@6.0.3)(zod@4.4.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
+
+  '@t3-oss/env-nextjs@0.13.11(typescript@6.0.3)(zod@4.4.3)':
+    dependencies:
+      '@t3-oss/env-core': 0.13.11(typescript@6.0.3)(zod@4.4.3)
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
 
   '@tailwindcss/node@4.3.2':
     dependencies:

--- a/src/lib/better-auth/auth.ts
+++ b/src/lib/better-auth/auth.ts
@@ -3,12 +3,13 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 
 import { DBClient } from "#/lib/drizzle/client";
 import { account, session, user, verification } from "#/lib/drizzle/schema";
+import { env } from "#/lib/env";
 
 export const auth = betterAuth({
-  appName: "Score Watcher",
+  appName: "next-template",
   basePath: "/api/auth",
-  baseURL: process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
+  baseURL: env.NEXT_PUBLIC_VERCEL_BRANCH_URL
+    ? `https://${env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
     : "http://localhost:3000",
   database: drizzleAdapter(DBClient, {
     provider: "sqlite",
@@ -21,22 +22,16 @@ export const auth = betterAuth({
   }),
   emailAndPassword: {
     // テスト環境のみ有効化
-    enabled: process.env.NODE_ENV !== "production",
+    enabled: env.NODE_ENV !== "production",
     requireEmailVerification: false, // テスト用のため検証不要
   },
   session: {
     expiresIn: 60 * 60 * 24 * 7, // 7 days
     updateAge: 60 * 60 * 24, // 1 day
   },
-  socialProviders: {
-    google: {
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    },
-  },
   trustedOrigins: [
-    process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL
-      ? `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
+    env.NEXT_PUBLIC_VERCEL_BRANCH_URL
+      ? `https://${env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
       : "http://localhost:3000",
   ],
 });

--- a/src/lib/better-auth/client.ts
+++ b/src/lib/better-auth/client.ts
@@ -1,9 +1,11 @@
 import { createAuthClient } from "better-auth/client";
 
+import { env } from "#/lib/env";
+
 export const authClient = createAuthClient({
   basePath: "/api/auth",
-  baseURL: process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
+  baseURL: env.NEXT_PUBLIC_VERCEL_BRANCH_URL
+    ? `https://${env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
     : "http://localhost:3000",
 });
 

--- a/src/lib/drizzle/client.ts
+++ b/src/lib/drizzle/client.ts
@@ -1,22 +1,13 @@
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 
+import { env } from "#/lib/env";
+
 import * as schema from "./schema/index";
 
-const tursoUrl = process.env.TURSO_CONNECTION_URL!;
-const tursoToken = process.env.TURSO_AUTH_TOKEN!;
-
-if (!tursoUrl) {
-  throw new Error("TURSO_CONNECTION_URL environment variable is required");
-}
-
-if (!tursoToken) {
-  throw new Error("TURSO_AUTH_TOKEN environment variable is required");
-}
-
 const sqlClient = createClient({
-  authToken: tursoToken,
-  url: tursoUrl,
+  authToken: env.TURSO_AUTH_TOKEN,
+  url: env.TURSO_CONNECTION_URL,
 });
 
 export const DBClient = drizzle(sqlClient, { schema });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,19 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import * as z from "zod";
+
+export const env = createEnv({
+  client: {
+    NEXT_PUBLIC_VERCEL_BRANCH_URL: z.string().optional(),
+  },
+  experimental__runtimeEnv: {
+    NEXT_PUBLIC_VERCEL_BRANCH_URL: process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL,
+    NODE_ENV: process.env.NODE_ENV,
+  },
+  server: {
+    TURSO_AUTH_TOKEN: z.string().min(1),
+    TURSO_CONNECTION_URL: z.url(),
+  },
+  shared: {
+    NODE_ENV: z.enum(["development", "production", "test"]).optional(),
+  },
+});


### PR DESCRIPTION
## 概要

環境変数が `process.env.XXX!` の非 null アサーション頼みで散在しており、未設定の検出がランタイムまで遅れる問題を解消するため、[t3-env](https://env.t3.gg/) (`@t3-oss/env-nextjs`) による型安全な環境変数バリデーションを導入します。

## 変更内容

- `@t3-oss/env-nextjs` を追加し、`src/lib/env.ts` に環境変数スキーマを定義
  - server: `TURSO_CONNECTION_URL` (URL 形式必須) / `TURSO_AUTH_TOKEN` (必須)
  - client: `NEXT_PUBLIC_VERCEL_BRANCH_URL` (Vercel 自動注入のため optional)
  - shared: `NODE_ENV`
- `next.config.ts` で `src/lib/env.ts` を副作用インポートし、ビルド時にバリデーションを実行
- `process.env` の直接参照を `env` オブジェクト経由に置き換え (`drizzle/client.ts`・`better-auth/auth.ts`・`better-auth/client.ts`・`drizzle.config.ts`)。手動の存在チェックと `!` アサーションを削除
- better-auth の `socialProviders` (Google) を削除 (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` が不要に)
- 他プロジェクトの残骸だった `appName: "Score Watcher"` を `"next-template"` に修正

## 検証

- [x] `pnpm run codecheck` 通過
- [x] `pnpm run build` 成功 (env バリデーションが通ることを確認)
- [x] `TURSO_CONNECTION_URL` を空にしたビルドが明確なエラーで失敗することを確認
- [x] `pnpm run test` 通過 (7 tests)
- [x] `drizzle-kit check` で drizzle.config.ts の読み込みを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
