### PR TITLE
ci(workflows): actionlint の導入と Auto Assign Author の修正

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,18 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download actionlint
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -5,11 +5,12 @@ on:
     types: [opened, reopened]
 
 permissions:
-  issues: write
+  pull-requests: write
 
 jobs:
   assign:
     runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     steps:
       - name: Assign author
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -23,5 +24,5 @@ jobs:
                 assignees: [context.payload.pull_request.user.login],
               });
             } catch (error) {
-              core.warning(`PR作成者のアサインに失敗しました: ${error.message}`);
+              core.setFailed(`PR作成者のアサインに失敗しました: ${error.message}`);
             }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Playwrightのバージョンを取得し、ブラウザのキャッシュキーを生成
         id: version-checker
         run: |
-          echo "playwright-version=$(npx playwright --version | sed 's/ //g')" >> $GITHUB_OUTPUT
+          echo "playwright-version=$(npx playwright --version | sed 's/ //g')" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: ブラウザのキャッシュを復元
         id: restore-chromium


### PR DESCRIPTION
## 概要

`.github/workflows/` 配下のワークフローに静的チェックがなかったため、[actionlint](https://github.com/rhysd/actionlint) を CI に導入します。あわせて、以前から動作していなかった Auto Assign Author ワークフローを修正します。

## 変更内容

### actionlint の導入

- `.github/workflows/actionlint.yml` を新規作成
  - ワークフローファイルを変更した PR (`paths: .github/workflows/**`) と `workflow_dispatch` で実行
  - 公式ダウンロードスクリプト方式で、スクリプト URL・バージョンとも v1.7.12 に固定 (リポジトリの SHA ピン方針に整合)
  - ubuntu-latest にプリインストールされた shellcheck により `run:` ステップのシェルスクリプトもチェック
- 既存ワークフローへの指摘を修正: `playwright.yml` の `>> $GITHUB_OUTPUT` を `>> "$GITHUB_OUTPUT"` に変更 (shellcheck SC2086)

### Auto Assign Author の修正

実行ログを調査したところ、`POST /repos/.../issues/{n}/assignees` が **403 Resource not accessible by integration** で失敗していました。トークン権限が `issues: write` のみで、PR へのアサインに必要な `pull-requests: write` がなかったことが原因です。さらに `catch` で `core.warning` に握りつぶしていたため、ジョブは常に成功扱いとなり問題が可視化されていませんでした。

- `permissions` を `issues: write` → `pull-requests: write` に変更 (403 の根本原因)
- `core.warning` → `core.setFailed` に変更し、失敗時にジョブが赤くなるように修正
- bot が作成した PR (dependabot 等) は bot をアサインできず必ず失敗するため、ジョブごとスキップする `if` 条件を追加

なお `pull_request_target` はベースブランチ (main) のワークフロー定義で実行されるため、この修正はマージ後に作成される PR から有効になります。

## 検証

- [x] ローカルで actionlint v1.7.12 + shellcheck を実行し、全ワークフローでエラー 0 を確認
- [x] CI 上で Actionlint ジョブが成功することを確認
- [ ] マージ後、新規 PR で Auto Assign Author が正常にアサインすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
