### PR TITLE
chore: Dependency Cooldown を7日に設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       time: "08:00"
     target-branch: "main"
     cooldown:
-      default-days: 1
+      default-days: 7
     ignore:
       - dependency-name: "typescript"
         versions: [">=7.0.0 <7.1.0"]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -58,6 +58,7 @@
     "oxc/no-optional-chaining": "off",
     "oxc/no-rest-spread-properties": "off",
     "react/forbid-component-props": "off",
+    "react/function-component-definition": ["warn", { "namedComponents": "arrow-function" }],
     "react/jsx-filename-extension": ["warn", { "extensions": [".tsx"] }],
     "react/jsx-max-depth": "off",
     "react/jsx-no-literals": "off",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1987,8 +1987,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  baseline-browser-mapping@2.11.7:
-    resolution: {integrity: sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==}
+  baseline-browser-mapping@2.11.6:
+    resolution: {integrity: sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4295,7 +4295,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  baseline-browser-mapping@2.11.7: {}
+  baseline-browser-mapping@2.11.6: {}
 
   better-auth@1.6.25(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.4))(next@16.2.12(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10(@types/node@26.1.2)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))):
     dependencies:
@@ -4794,7 +4794,7 @@ snapshots:
     dependencies:
       '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.11.7
+      baseline-browser-mapping: 2.11.6
       caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,4 @@ allowBuilds:
   lefthook: true
   sharp: true
 saveExact: true
-minimumReleaseAge: 1440
+minimumReleaseAge: 10080


### PR DESCRIPTION
## 概要

新しくリリースされた依存パッケージを即座に取り込まないよう、cooldown 期間を1日から7日に延長します。

## 変更内容

### `.github/dependabot.yml`

- `cooldown.default-days` を `1` → `7` に変更

### `pnpm-workspace.yaml`

- `minimumReleaseAge` を `1440`（1日）→ `10080`（7日）に変更

### `pnpm-lock.yaml`

- `baseline-browser-mapping` を `2.11.7` → `2.11.6` にダウングレード
  - `2.11.7` は公開から約6.98日で、新しい7日の cooldown を満たしていなかったため
  - `next@16.2.12` の推移的依存で、要求範囲は `^2.9.19` のため `2.11.6` でも問題なし

その他の直接依存・推移的依存は、すべて公開から7日以上経過していたためダウングレード不要でした。

## 確認事項

- `pnpm install` が supply-chain policy チェックを通過することを確認
- `pnpm run codecheck` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: oxlint の warning 解消

`pnpm run codecheck` で出ていた124件の warning はすべて `react(function-component-definition)` でした。

これは既存の `"func-style": ["error", "expression"]` と正面から衝突しています。実際に `src/app/not-found.tsx` をアロー関数から関数宣言へ書き換えて検証したところ、warning は消える代わりに `eslint(func-style)` の **error** が発生し、両ルールが排他的であることを確認しました。

コードベースは一貫して `func-style: expression`（アロー関数の const 定義）を採用しているため、ルール側をその方針に合わせます。

### `.oxlintrc.json`

- `react/function-component-definition` に `{ "namedComponents": "arrow-function" }` を指定

ルールを `off` にするのではなくオプションで方針を揃えたので、コンポーネント定義スタイルの一貫性チェック自体は引き続き有効です。

これにより `pnpm run codecheck` は warning・error ともに0件になりました。
