### PR TITLE
chore: Dependabot に GitHub Actions の更新を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,16 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Tokyo"
+      time: "08:00"
+    target-branch: "main"
+    cooldown:
+      default-days: 7
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` に `github-actions` エコシステムを追加し、ワークフローで使用している GitHub Actions も自動更新の対象にしました。

## 背景

これまで Dependabot は npm のみを監視しており、`.github/workflows/` 配下で使用している以下のアクションは手動更新が必要でした。

- `actions/checkout`
- `actions/setup-node`
- `actions/cache` / `actions/cache/restore`
- `actions/upload-artifact`
- `actions/github-script`
- `pnpm/action-setup`
- `dependabot/fetch-metadata`

これらはすべてコミット SHA でピン留めされているため更新漏れが起きやすく、Dependabot は SHA ピン留めのアクションもバージョンコメント (`# v6.0.2` など) 込みで更新できるため、npm と同じ運用に揃えました。

## 変更内容

- `github-actions` エコシステムのエントリを追加
- スケジュール (weekly / Asia/Tokyo 08:00) と `cooldown` は既存の npm エントリと同じ設定
- グループ名は npm 側の `all-dependencies` と衝突しないよう `all-actions` を使用
- `directory: "/"` は GitHub Actions では `.github/workflows/` を指す規約

## 影響範囲

`dependabot-auto-merge.yml` は作成者が `dependabot[bot]` かどうかのみを条件にしているため、Actions 更新 PR も CI 通過後に auto-merge されます。

## 動作確認

- `pnpm run codecheck` が通過することを確認
- マージ後、Insights → Dependency graph → Dependabot に `github-actions` のジョブが表示されることを確認予定