### PR TITLE
fix: Playwright CI で Turso の secrets ではなくローカル SQLite を使う

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,8 +9,8 @@ concurrency:
 jobs:
   test:
     env:
-      TURSO_CONNECTION_URL: ${{ secrets.TURSO_CONNECTION_URL }}
-      TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+      TURSO_CONNECTION_URL: file:ci.db
+      TURSO_AUTH_TOKEN: ci
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -44,6 +44,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ steps.version-checker.outputs.playwright-version }}
+      - name: テスト用データベースを準備
+        run: pnpm exec drizzle-kit migrate
       - name: ビルドキャッシュを復元
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ next-env.d.ts
 
 # CSS Modules Kit
 generated
+
+# テスト用のローカル SQLite
+ci.db


### PR DESCRIPTION
## 背景

Dependabot の PR で Playwright Tests が失敗していました。

https://github.com/newt239/next-template/actions/runs/32254788611/job/96073863792

```
TURSO_CONNECTION_URL:
TURSO_AUTH_TOKEN:
❌ Invalid environment variables
```

`TURSO_CONNECTION_URL` / `TURSO_AUTH_TOKEN` はリポジトリの Actions secrets に設定済みですが、**Dependabot が作成した PR のワークフローには Actions secrets が渡されません**(GitHub の仕様で、別枠の Dependabot secrets が使われます)。そのため env が空文字となり `next build` の env バリデーションで落ちていました。同じ理由で fork からの PR でも失敗します。

## 変更内容

- Playwright ワークフローで secrets を参照するのをやめ、CI 専用のローカル SQLite (`file:ci.db`) を使うようにしました
- テスト前に `drizzle-kit migrate` でスキーマを適用するステップを追加しました
- `.gitignore` に `ci.db` を追加しました

これにより Dependabot PR・fork PR でも E2E テストが実行できるようになり、本番 DB にテストデータが書き込まれることもなくなります。

## 動作確認

ローカルで `TURSO_CONNECTION_URL=file:ci.db TURSO_AUTH_TOKEN=ci` を指定し、以下を確認しました。

- `drizzle-kit migrate` がローカル SQLite に対して成功すること
- dev サーバーが起動しホームページが 200 を返すこと
