### PR TITLE
fix: 設定と CI のレビュー指摘を修正する

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download actionlint
-        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
       - name: Run actionlint
         run: ./actionlint -color
+      - name: Verify that actions are pinned to commit SHAs
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   actionlint:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -44,5 +44,3 @@ jobs:
         run: pnpm run ls-lint
       - name: Knip
         run: pnpm run knip
-      - name: Build
-        run: pnpm run build

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -19,7 +19,6 @@ jobs:
       TURSO_CONNECTION_URL: file:ci.db
       TURSO_AUTH_TOKEN: ci
       BETTER_AUTH_SECRET: ci-dummy-secret-not-used-in-production
-      BETTER_AUTH_URL: http://localhost:3000
       NEXT_TELEMETRY_DISABLED: 1
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -21,6 +21,7 @@ jobs:
       BETTER_AUTH_SECRET: ci-dummy-secret-not-used-in-production
       BETTER_AUTH_URL: http://localhost:3000
       NEXT_TELEMETRY_DISABLED: 1
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -19,6 +19,7 @@ jobs:
       TURSO_CONNECTION_URL: file:ci.db
       TURSO_AUTH_TOKEN: ci
       BETTER_AUTH_SECRET: ci-dummy-secret-not-used-in-production
+      BETTER_AUTH_URL: http://localhost:3000
       NEXT_TELEMETRY_DISABLED: 1
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,7 @@ jobs:
       TURSO_CONNECTION_URL: file:ci.db
       TURSO_AUTH_TOKEN: ci
       BETTER_AUTH_SECRET: ci-dummy-secret-not-used-in-production
+      BETTER_AUTH_URL: http://localhost:3000
       E2E_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,6 @@ jobs:
       TURSO_CONNECTION_URL: file:ci.db
       TURSO_AUTH_TOKEN: ci
       BETTER_AUTH_SECRET: ci-dummy-secret-not-used-in-production
-      BETTER_AUTH_URL: http://localhost:3000
       E2E_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: 1
       - name: Playwrightのテストを実行
-        run: pnpm exec playwright test --workers=2
+        run: pnpm run test:e2e
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ next-env.d.ts
 generated
 
 # テスト用のローカル SQLite
-ci.db
+ci.db*

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -26,6 +26,5 @@
   "sortPackageJson": {
     "sortScripts": true
   },
-  "sortTailwindcss": true,
-  "jsdoc": true
+  "sortTailwindcss": true
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -44,7 +44,6 @@
     "one-var": "off",
     "require-unicode-regexp": "off",
     "sort-imports": "off",
-    "sort-keys": "warn",
     "import/consistent-type-specifier-style": "off",
     "import/exports-last": "off",
     "import/group-exports": "off",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,7 +13,7 @@ export const env = createEnv({
   },
   server: {
     BETTER_AUTH_SECRET: z.string().min(32),
-    BETTER_AUTH_URL: z.url().optional(),
+    BETTER_AUTH_URL: z.url(),
     TURSO_AUTH_TOKEN: z.string().min(1),
     TURSO_CONNECTION_URL: z.url(),
   },

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,7 +13,7 @@ export const env = createEnv({
   },
   server: {
     BETTER_AUTH_SECRET: z.string().min(32),
-    BETTER_AUTH_URL: z.url(),
+    BETTER_AUTH_URL: z.url().optional(),
     TURSO_AUTH_TOKEN: z.string().min(1),
     TURSO_CONNECTION_URL: z.url(),
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "noImplicitOverride": true,
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
-    "forceConsistentCasingInFileNames": true, // ファイル名の大文字・小文字の不一致によるバグを防ぐ
     "noEmit": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
## 概要

<!-- 何を・なぜ変更したかを簡潔に記述してください -->

テンプレート全体を読み直したときに見つかった、設定と CI の不整合をまとめて直します。挙動が変わるのは `codecheck` からビルドを外した点だけです。

## 変更内容

<!-- 主な変更点を箇条書きで記述してください -->

- actionlint のダウンロードスクリプトの取得元を、タグ `v1.7.12` からその時点のコミット `914e7df` に固定しました。他の action はすべて commit SHA で固定しているのに、ここだけ付け替え可能なタグを参照していました
- あわせて `suzuki-shunsuke/pinact-action` を `fix: "false"` で追加し、固定漏れがあれば CI で落ちるようにしました。このワークフローは `.github/workflows/**` の変更で走るため、この PR 自身が追加分の検証を兼ねています
- `codecheck` から `pnpm run build` を外しました。同じコミットを Playwright のジョブがビルドしているため、PR ごとにフルビルドが 2 回走っていました
- Playwright の並列数の指定を `playwright.config.ts` に一本化しました。ワークフロー側の `--workers=2` が設定ファイルの `workers` と同じ値で重複していました
- `codecheck` と `actionlint` のジョブに `timeout-minutes: 10` を設定しました。Playwright のジョブにだけ入っていました
- `tsconfig.json` の `forceConsistentCasingInFileNames` を削除しました。今の TypeScript では既定で有効です。`allowJs` は Next.js の `writeConfigurationDefaults` が suggested として書き戻すため残しています
- `.oxlintrc.json` の `"sort-keys": "warn"` を削除しました。`sort-keys` は `style` カテゴリのルールで、`categories` 側ですでに `warn` にしています
- `.oxfmtrc.json` の `"jsdoc": true` を削除しました。AGENTS.md でコメントを原則禁止しているため対象がありません
- `.gitignore` の `ci.db` を `ci.db*` にしました。WAL モードで生成される `-wal` と `-shm` を拾えていませんでした

## 動作確認

<!-- 確認した内容にチェックを入れてください -->

- [x] `pnpm run codecheck` が通ることを確認した
- [x] `pnpm run build` が通ることを確認した
- [x] 影響範囲の動作を確認した

ローカルの SQLite に向けて E2E を実行し、7 件すべてが通ることを確認しました。`pinact run --check` もローカルで通っています。`forceConsistentCasingInFileNames` については、削除後に `next typegen` を実行しても再追加されないことを確認しました。

## 補足

<!-- レビュアーに伝えたいことがあれば記述してください。不要なら削除してかまいません -->

`codecheck` からビルドを外したことで、`push: main` ではビルドが走らなくなります。main は PR 経由でしか進まず PR 側ではビルドされるため実質は保てていますが、判断が分かれるところだと思います。

この PR には当初 `BETTER_AUTH_URL` を必須にする変更も入れていましたが、Vercel のプレビューデプロイが落ちたため取り消しました (897099e とその revert)。`better-auth` の `getTrustedOrigins` は `baseURL` が文字列で渡っていないとリクエスト自身から baseURL を導出するため、`trustedOrigins` がそのリクエストのオリジンになり origin チェックが素通りします。ただし Vercel のプレビューはデプロイごとに URL が変わるので、単一の静的な URL を必須にするのは筋が悪く、`trustedOrigins` を明示するか `baseURL` の動的設定を使うかを別途検討したほうがよさそうです。

`tests/e2e/helpers/cleanup.ts` が `ON DELETE cascade` に依存している点も疑いましたが、`@libsql/client` が接続時に `PRAGMA foreign_keys` を有効にしていて cascade は正しく発火していたため、変更していません。
